### PR TITLE
Support Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,15 @@
     ],
     "require": {
         "php": "^8.3",
-        "illuminate/contracts": "^11.0|^12.0",
-        "illuminate/process": "^11.0|^12.0",
-        "illuminate/support": "^11.0|^12.0"
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
+        "illuminate/process": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.17",
         "larastan/larastan": "^3.0",
         "mockery/mockery": "^1.6",
-        "orchestra/testbench": "^9.4|^10.0",
+        "orchestra/testbench": "^9.4|^10.0|^11.0",
         "pestphp/pest": "^3.0",
         "pestphp/pest-plugin-arch": "^3.0",
         "pestphp/pest-plugin-laravel": "^3.0",


### PR DESCRIPTION
This PR adds support for Laravel 13 by updating the version constraints in `composer.json` and verifying compatibility. Closes #1